### PR TITLE
nak-with-delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ no.cjohansen/clj-nats {:git/url "https://github.com/cjohansen/clj-nats"
                        :sha "LATEST_SHA"}
 ```
 
-The current jnats version is `2.19.1`.
+The current jnats version is `2.20.2`.
 
 ## Status
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "target/classes"]
- :deps {io.nats/jnats {:mvn/version "2.19.1"}}
+ :deps {io.nats/jnats {:mvn/version "2.20.2"}}
  :aliases
  {:dev {:extra-paths ["dev"]
         :extra-deps {org.clojure/core.async {:mvn/version "1.6.681"}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>io.nats</groupId>
       <artifactId>jnats</artifactId>
-      <version>2.19.0</version>
+      <version>2.20.2</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Need to be able to slow down one of our message processors for an external server that returns 500 with an inner body that includes "<ExceptionMessage>The remote server returned an error: (429) Too Many Requests.</ExceptionMessage>";)
