### PR TITLE
Encourage use of `:git/sha` for git deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install:
 
 ```clj
 no.cjohansen/clj-nats {:git/url "https://github.com/cjohansen/clj-nats"
-                       :sha "LATEST_SHA"}
+                       :git/sha "LATEST_SHA"}
 ```
 
 The current jnats version is `2.20.2`.


### PR DESCRIPTION
Hi!

The [official Clojure deps.edn reference] encourages `:git/sha` for Git SHAs.

<img width="603" alt="image" src="https://github.com/user-attachments/assets/069fe98a-9ea6-4000-998f-0c13a0edde75">

I think maybe `:sha` works for backwards compatibility.

Does it make sense to update the README?

[official Clojure deps.edn reference]: https://clojure.org/reference/deps_edn