### PR TITLE
`:nats.consumer/inactive-threshold` typo

### DIFF
--- a/src/nats/consumer.clj
+++ b/src/nats/consumer.clj
@@ -69,7 +69,7 @@
              ::durable (.getDurable config)
              ::filter-subjects (.getFilterSubjects config)
              ::idle-heartbeat (.getIdleHeartbeat config)
-             ::inactve-threshold (.getInactiveThreshold config)
+             ::inactive-threshold (.getInactiveThreshold config)
              ::max-ack-pending (.getMaxAckPending config)
              ::max-batch (.getMaxBatch config)
              ::max-bytes (.getMaxBytes config)

--- a/test/nats/integration_test.clj
+++ b/test/nats/integration_test.clj
@@ -526,7 +526,7 @@
              :nats.consumer/metadata {}
              :nats.consumer/sample-frequency nil
              :nats.consumer/rate-limit-was-set? false
-             :nats.consumer/inactve-threshold nil
+             :nats.consumer/inactive-threshold nil
              :nats.consumer/max-deliver-was-set? true
              :nats.consumer/pause-until nil
              :nats.consumer/max-expires nil


### PR DESCRIPTION
Typo for a consumer's `inactive-threshold` (prev: `inactve-threshold`).

I was trying to destructure `inactive-threshold` from `:nats.consumer/consumer-configuration` from `get-consumer-info` and I kept receiving nil!